### PR TITLE
Remove hardcoded limit of 50 on `max_attempts`

### DIFF
--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -162,7 +162,7 @@ defmodule Oban.Job do
     |> put_state()
     |> validate_length(:queue, min: 1, max: 128)
     |> validate_length(:worker, min: 1, max: 128)
-    |> validate_number(:max_attempts, greater_than: 0, less_than: 50)
+    |> validate_number(:max_attempts, greater_than: 0)
     |> validate_number(:priority, greater_than: -1, less_than: 4)
   end
 


### PR DESCRIPTION
It looks like this has been [implemented in the official repo](https://github.com/sorentwo/oban/commit/e75268420df4a0841a6dc1a9bf9f656de6cb71ce#diff-54ac3ebdac6b8a4bd2fadc1c57f2fca4L169) and will be released in the next version after 1.2.0.